### PR TITLE
use current locale in DateTimePlugin

### DIFF
--- a/src/lib/date-time-plugin.test.ts
+++ b/src/lib/date-time-plugin.test.ts
@@ -78,4 +78,18 @@ describe("DateTime Plugin", () => {
         plugin = createDateTimePlugin("de-DE", "UTC");
         expect(plugin("xxxx [[date]] xxx [[date]]", {}, new Translator())).not.toBe("xxxx [[date]] xxx [[date]]");
     });
+
+    test("uses current locale", () => {
+        plugin = createDateTimePlugin(undefined, "UTC");
+        const translator = new Translator();
+        translator.locale("de-DE");
+        const date = new Date("1998-01-07T18:30:00+02:00");
+        expect(plugin("xxxx [[date|date|medium]] xxx [[date|date|long]]", {replace: {date}}, translator)).toBe(
+            "xxxx 7. Jan. 1998 xxx 7. Januar 1998",
+        );
+        translator.locale("en-US");
+        expect(plugin("xxxx [[date|date|medium]] xxx [[date|date|long]]", {replace: {date}}, translator)).toBe(
+            "xxxx Jan 7, 1998 xxx January 7, 1998",
+        );
+    });
 });

--- a/src/lib/date-time-plugin.ts
+++ b/src/lib/date-time-plugin.ts
@@ -58,7 +58,7 @@ export function createDateTimePlugin(
     formats?: Formats,
 ): TranslatorPlugin {
     return function (translated: string, options, translator) {
-        locale = locale ?? translator.long();
+        const currentLocale = locale ?? translator.long();
 
         const sets = [
             {
@@ -99,7 +99,7 @@ export function createDateTimePlugin(
 
                 translated = translated.replace(
                     value.match,
-                    new Intl.DateTimeFormat(locale.toString(), {
+                    new Intl.DateTimeFormat(currentLocale.toString(), {
                         ...(formats || defaultFormats)[format],
                         ...reduce,
                         timeZone,


### PR DESCRIPTION
Use the current locale in DateTimePlugin when no forced locale was set in creation of the plugin.

Fixes #25 