### PR TITLE
call plugins with the locale used to translate the key

### DIFF
--- a/src/lib/currency-plugin.test.ts
+++ b/src/lib/currency-plugin.test.ts
@@ -21,21 +21,21 @@ describe("Currency Plugin", () => {
     test("can parse [[currency]] with forced locale", () => {
         plugin = createCurrencyPlugin("de-DE", "EUR");
         testCases.forEach((test) => {
-            expect(plugin(test.q, testOptions, new Translator())).toBe(test.e);
+            expect(plugin(test.q, testOptions, "en-US", new Translator())).toBe(test.e);
         });
     });
 
     test("can parse [[currency]] with locale passed by translator", () => {
         plugin = createCurrencyPlugin(undefined, "EUR");
         testCases.forEach((test) => {
-            expect(plugin(test.q, testOptions, new Translator({default: "de-DE"}))).toBe(test.e);
+            expect(plugin(test.q, testOptions, "de-DE", new Translator())).toBe(test.e);
         });
     });
 
     test("can parse [[currency]] without currency (will use USD)", () => {
         plugin = createCurrencyPlugin();
         testCases.forEach((test) => {
-            expect(plugin(test.q, testOptions, new Translator({default: "de-DE"}))).toBe(test.e.replace(/€/g, "$"));
+            expect(plugin(test.q, testOptions, "de-DE", new Translator())).toBe(test.e.replace(/€/g, "$"));
         });
     });
 });

--- a/src/lib/currency-plugin.ts
+++ b/src/lib/currency-plugin.ts
@@ -11,9 +11,9 @@ export function createCurrencyPlugin(
         ...{style: "currency"},
     };
 
-    return function (translated: string, options, translator) {
+    return function (translated: string, options, usedLocale) {
         const values = Parser(translated, "currency");
-        const locale = forcedLocale || translator.long();
+        const locale = forcedLocale || usedLocale;
 
         values.forEach((value) => {
             const pattern: string | undefined = value.arguments[0];

--- a/src/lib/date-time-plugin.test.ts
+++ b/src/lib/date-time-plugin.test.ts
@@ -36,7 +36,7 @@ describe("DateTime Plugin", () => {
             },
         ].forEach((test) => {
             const date = new Date("1998-01-07T18:30:00+02:00");
-            expect(plugin(test.q, {replace: {date}}, new Translator())).toBe(test.e);
+            expect(plugin(test.q, {replace: {date}}, "en-US", new Translator())).toBe(test.e);
         });
     });
 
@@ -70,26 +70,25 @@ describe("DateTime Plugin", () => {
                 e: "xxxx 7. Jan. 1998, 16:30 xxx 7. Jan. 1998, 17:30",
             },
         ].forEach((test) => {
-            expect(plugin(test.q, {}, new Translator())).toBe(test.e);
+            expect(plugin(test.q, {}, "en-US", new Translator())).toBe(test.e);
         });
     });
 
     test("can parse [[date]] without a date", () => {
         plugin = createDateTimePlugin("de-DE", "UTC");
-        expect(plugin("xxxx [[date]] xxx [[date]]", {}, new Translator())).not.toBe("xxxx [[date]] xxx [[date]]");
+        expect(plugin("xxxx [[date]] xxx [[date]]", {}, "en-US", new Translator())).not.toBe(
+            "xxxx [[date]] xxx [[date]]",
+        );
     });
 
     test("uses current locale", () => {
         plugin = createDateTimePlugin(undefined, "UTC");
-        const translator = new Translator();
-        translator.locale("de-DE");
         const date = new Date("1998-01-07T18:30:00+02:00");
-        expect(plugin("xxxx [[date|date|medium]] xxx [[date|date|long]]", {replace: {date}}, translator)).toBe(
-            "xxxx 7. Jan. 1998 xxx 7. Januar 1998",
-        );
-        translator.locale("en-US");
-        expect(plugin("xxxx [[date|date|medium]] xxx [[date|date|long]]", {replace: {date}}, translator)).toBe(
-            "xxxx Jan 7, 1998 xxx January 7, 1998",
-        );
+        expect(
+            plugin("xxxx [[date|date|medium]] xxx [[date|date|long]]", {replace: {date}}, "de-DE", new Translator()),
+        ).toBe("xxxx 7. Jan. 1998 xxx 7. Januar 1998");
+        expect(
+            plugin("xxxx [[date|date|medium]] xxx [[date|date|long]]", {replace: {date}}, "en-US", new Translator()),
+        ).toBe("xxxx Jan 7, 1998 xxx January 7, 1998");
     });
 });

--- a/src/lib/date-time-plugin.ts
+++ b/src/lib/date-time-plugin.ts
@@ -57,8 +57,8 @@ export function createDateTimePlugin(
     defaultFormat?: string,
     formats?: Formats,
 ): TranslatorPlugin {
-    return function (translated: string, options, translator) {
-        const currentLocale = locale ?? translator.long();
+    return function (translated: string, options, usedLocale) {
+        const currentLocale = locale ?? usedLocale;
 
         const sets = [
             {

--- a/src/lib/number-plugin.test.ts
+++ b/src/lib/number-plugin.test.ts
@@ -33,14 +33,14 @@ describe("Currency Plugin", () => {
     test("can parse [[number]] with forced locale", () => {
         plugin = createNumberPlugin("de-DE");
         testCasesOne.forEach((test) => {
-            expect(plugin(test.q, testOptions, new Translator())).toBe(test.e);
+            expect(plugin(test.q, testOptions, "en-US", new Translator())).toBe(test.e);
         });
     });
 
     test("can parse [[number]] with locale from translator", () => {
         plugin = createNumberPlugin();
         testCasesOne.forEach((test) => {
-            expect(plugin(test.q, testOptions, new Translator({default: "de-DE"}))).toBe(test.e);
+            expect(plugin(test.q, testOptions, "de-DE", new Translator())).toBe(test.e);
         });
     });
 
@@ -50,7 +50,7 @@ describe("Currency Plugin", () => {
             minimumFractionDigits: 1,
         });
         testCasesTwo.forEach((test) => {
-            expect(plugin(test.q, testOptions, new Translator())).toBe(test.e);
+            expect(plugin(test.q, testOptions, "en-US", new Translator())).toBe(test.e);
         });
     });
 });

--- a/src/lib/number-plugin.ts
+++ b/src/lib/number-plugin.ts
@@ -10,9 +10,9 @@ export function createNumberPlugin(
         ...{style: "decimal"},
     };
 
-    return function (translated: string, options, translator) {
+    return function (translated: string, options, usedLocale) {
         const values = Parser(translated, "number");
-        const locale = forcedLocale || translator.long();
+        const locale = forcedLocale || usedLocale;
 
         values.forEach((value) => {
             const pattern: string | undefined = value.arguments[0];

--- a/src/lib/translator.test.ts
+++ b/src/lib/translator.test.ts
@@ -320,7 +320,7 @@ describe("Translator", () => {
 
     describe("Plugins", () => {
         const createPlugin = (result = "test") =>
-            jest.fn<string | undefined, [string, Partial<TranslateOptions>, TranslatorInterface]>(() => result);
+            jest.fn<string | undefined, [string, Partial<TranslateOptions>, string, TranslatorInterface]>(() => result);
 
         beforeEach(() => {
             instance.addResource("en", {t: "[[test]]"});
@@ -352,9 +352,24 @@ describe("Translator", () => {
             instance.addPlugin(short, instance.short());
             instance.addPlugin(global);
             expect(instance.t("t")).toBe("global");
-            expect(long).toHaveBeenCalledWith("[[test]]", expect.anything(), expect.anything());
-            expect(short).toHaveBeenCalledWith("long", expect.anything(), expect.anything());
-            expect(global).toHaveBeenCalledWith("short", expect.anything(), expect.anything());
+            expect(long).toHaveBeenCalledWith("[[test]]", expect.anything(), expect.anything(), expect.anything());
+            expect(short).toHaveBeenCalledWith("long", expect.anything(), expect.anything(), expect.anything());
+            expect(global).toHaveBeenCalledWith("short", expect.anything(), expect.anything(), expect.anything());
+        });
+
+        test("plugin is called with used (long)locale or fallback", () => {
+            instance.addResource("de", {de: "[[test]]"});
+            instance.addResource("de-DE", {dede: "[[test]]"});
+            const p = createPlugin();
+            instance.addPlugin(p);
+            instance.locale("de-DE");
+
+            expect(instance.t("dede")).toBe("test");
+            expect(p).toHaveBeenCalledWith("[[test]]", expect.anything(), "de-DE", expect.anything());
+            expect(instance.t("de")).toBe("test");
+            expect(p).toHaveBeenCalledWith("[[test]]", expect.anything(), "de-DE", expect.anything());
+            expect(instance.t("t")).toBe("test");
+            expect(p).toHaveBeenCalledWith("[[test]]", expect.anything(), "en", expect.anything());
         });
     });
 });

--- a/src/lib/translator.test.ts
+++ b/src/lib/translator.test.ts
@@ -78,6 +78,14 @@ describe("Translator", () => {
         expect(instance.long()).toBe("de-DE");
     });
 
+    test("should not trigger listener on deprecated language change when changing to same language", () => {
+        instance.language("de");
+        const spy = jest.fn();
+        instance.listen(spy);
+        instance.language("de");
+        expect(spy).not.toHaveBeenCalled();
+    });
+
     test("should trigger listener on language change", () => {
         const spy = jest.fn();
         instance.listen(spy);
@@ -370,6 +378,17 @@ describe("Translator", () => {
             expect(p).toHaveBeenCalledWith("[[test]]", expect.anything(), "de-DE", expect.anything());
             expect(instance.t("t")).toBe("test");
             expect(p).toHaveBeenCalledWith("[[test]]", expect.anything(), "en", expect.anything());
+        });
+
+        test("plugin may return undefined for not changing anything", () => {
+            instance.addPlugin(createPlugin().mockImplementation(() => undefined));
+            expect(instance.t("t")).toBe("[[test]]");
+        });
+
+        test("can add multiple plugins for same language", () => {
+            instance.addPlugin(jest.fn((t: string) => t.replace("[[te", "foo")));
+            instance.addPlugin(jest.fn((t: string) => t.replace("st]]", "bar")));
+            expect(instance.t("t")).toBe("foobar");
         });
     });
 });

--- a/src/lib/translator.ts
+++ b/src/lib/translator.ts
@@ -50,12 +50,13 @@ export class Translator implements TranslatorInterface {
         //   if none found find by short locale like "de"
         //   if still none found search by the fallback which is by default "en"
         let translated = "";
+        let usedFallback = false;
         const currentLanguagePattern = this._patternFor(key, options, false);
         const foundTranslationInCurrentLanguage = [this.long(), this.short()].some((tag) =>
             currentLanguagePattern.some((pat) => !!(translated = this._resources[`${tag}.${pat}`])),
         );
         if (!foundTranslationInCurrentLanguage) {
-            this._patternFor(key, options, true).some(
+            usedFallback = this._patternFor(key, options, true).some(
                 (pat) => !!(translated = this._resources[`${this._options.fallback}.${pat}`]),
             );
         }
@@ -77,7 +78,9 @@ export class Translator implements TranslatorInterface {
             .concat(this._registry[this.short()] || [])
             .concat(this._registry[GLOBAL] || [])
             .forEach((plugin) => {
-                translated = plugin(translated, options, this) || translated;
+                translated =
+                    plugin(translated, options, usedFallback ? this._options.fallback : this.long(), this) ||
+                    translated;
             });
 
         return translated;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -41,6 +41,7 @@ export type Unsubscribe = () => void;
 export type TranslatorPlugin = (
     translated: string,
     options: Partial<TranslateOptions>,
+    usedLocale: string,
     translator: TranslatorInterface,
 ) => string | undefined;
 


### PR DESCRIPTION
pass the used locale (long for short and long, or fallback) to the plugins to provide a consistent translation
 
Fixes #24 